### PR TITLE
Changing when statement

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -13,4 +13,4 @@
 
 - name: Update CA Trust (Debian, Ubuntu)
   command: update-ca-certificates
-  when: result | changed
+  when: result is changed


### PR DESCRIPTION
result | changed no longer works in 2.9